### PR TITLE
Clean up sdl.go

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,11 @@
+# This is the official list of Go-SDL2 authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS files.
+# See the latter for an explanation.
+
+# Names should be added to this file as
+#   Name or Organization <email address>
+# The email address is not required for organizations.
+
+# Please keep the list sorted.
+
+Adam Hintz <adamh.zero@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@
 # Please keep the list sorted.
 
 Adam Hintz <adamh.zero@gmail.com>
+Google Inc.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,11 @@
+# This is the official list of people who can contribute
+# (and typically have contributed) code to the Go-SDL2 repository.
+# The AUTHORS file lists the copyright holders; this file
+# lists people.
+#
+# Names should be added to this file like so:
+#     Name <email address>
+
+# Please keep the list sorted.
+
+Adam Hintz <adamh.zero@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@
 # Please keep the list sorted.
 
 Adam Hintz <adamh.zero@gmail.com>
+Ross Light <light@google.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Adam Hintz
+Copyright (c) 2014 Go-SDL2 Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-Go-SDL2 is my attempt to make Go bindings for SDL version 2, known as "SDL2".
+Go-SDL2 is a collection of packages for Go bindings for the
+[Simple DirectMedia Layer](http://libsdl.org) version 2, known as "SDL2".
 
-I'm using this for a (privately hosted) project of my own, so I'll be adding to
-the bindings as needed.
+These bindings aim to be very Go-idiomatic and intuitive, and will include
+bindings for SDL packages such as SDL-ttf, SDL-image, and more.
 
-Huge thanks to Ross Light for assisting me with questions and problems I had
-with this project.
+Examples of how to use these packages are available
+[here](https://github.com/adam000/go-sdl-gl-examples).
 
 *This software is provided free of charge. See LICENSE for details.*


### PR DESCRIPTION
Various clean-ups to docs and such for sdl.go.  There's a slight breaking change for callers of Init (returns an error instead of an int), but otherwise, no API change.
