### PR TITLE
Separate image.go into an image package

### DIFF
--- a/demos/showimage/.gitignore
+++ b/demos/showimage/.gitignore
@@ -1,0 +1,1 @@
+showimage

--- a/demos/showimage/showimage.go
+++ b/demos/showimage/showimage.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/adam000/Go-SDL2/image"
+	"github.com/adam000/Go-SDL2/sdl"
+)
+
+var fullscreen = flag.Bool("fullscreen", false, "fullscreen window")
+
+func main() {
+	flag.Parse()
+	defer sdl.Quit()
+
+	// Open window
+	var windowFlags sdl.WindowFlag
+	if *fullscreen {
+		windowFlags |= sdl.WindowFullscreen
+	}
+	// TODO(light): surface width & height
+	window, err := sdl.NewWindow(flag.Arg(0), 0, 0, 640, 480, windowFlags)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	renderer, err := sdl.NewRenderer(window, -1, 0)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// Load textures
+	textures := make([]sdl.Texture, flag.NArg())
+	for i, name := range flag.Args() {
+		surf, err := image.Load(name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %v", name, err)
+			os.Exit(1)
+		}
+		textures[i], err = surf.ToTexture(renderer)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %v", name, err)
+			os.Exit(1)
+		}
+	}
+	defer func() {
+		for _, tex := range textures {
+			tex.Destroy()
+		}
+	}()
+
+	// Display
+	currTex := 0
+mainLoop:
+	for {
+		// Poll for events
+		for {
+			ev := sdl.PollEvent()
+			if ev == nil {
+				break
+			}
+			switch ev.Type() {
+			case sdl.QuitEv:
+				fmt.Println("QUIT")
+				break mainLoop
+			case sdl.KeyDownEv:
+				fmt.Println("KEY")
+				// TODO(light): advance texture
+			}
+		}
+
+		// Display image
+		renderer.Clear()
+		renderer.CopyTexture(textures[currTex], nil, nil)
+		renderer.Present()
+
+		// Wait a bit
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/image/image.go
+++ b/image/image.go
@@ -7,19 +7,47 @@ package image
 // #include "SDL_image.h"
 import "C"
 
-import "unsafe"
+import (
+	"unsafe"
 
-func Init() {
+	"github.com/adam000/Go-SDL2/sdl"
+)
+
+// An InitFlag represents a set of image libraries to load.
+type InitFlag uint32
+
+// Initialization flags.
+const (
+	InitJPG  InitFlag = C.IMG_INIT_JPG
+	InitPNG  InitFlag = C.IMG_INIT_PNG
+	InitTIF  InitFlag = C.IMG_INIT_TIF
+	InitWEBP InitFlag = C.IMG_INIT_WEBP
+)
+
+// Init loads dynamic libraries.  Multiple flags will be ORed together.
+// Init returns the libraries succesfully initialized.  It is not
+// required to call Init before using other functions in this package.
+func Init(flags ...InitFlag) InitFlag {
+	var f InitFlag
+	for i := range flags {
+		f |= flags[i]
+	}
+	return InitFlag(C.IMG_Init(C.int(f)))
 }
 
-func LoadImage(fileName string) (Surface, error) {
-	cName := C.CString(fileName)
-	surf := C.IMG_Load(cName)
-	C.free(unsafe.Pointer(cName))
+// Quit unloads libraries loaded with Init.
+func Quit() {
+	C.IMG_Quit()
+}
+
+// Load reads an image from a file.
+func Load(file string) (sdl.Surface, error) {
+	cfile := C.CString(file)
+	defer C.free(unsafe.Pointer(cfile))
+	surf := C.IMG_Load(cfile)
 
 	if surf == nil {
-		return Surface{}, getError()
+		return sdl.InternalSurface(nil), sdl.GetError()
 	}
-
-	return Surface{surf}, nil
+	return sdl.InternalSurface(unsafe.Pointer(surf)), nil
 }

--- a/image/image.go
+++ b/image/image.go
@@ -1,13 +1,16 @@
-package sdl
+// Package image provides access to popular image formats via SDL_image.
+package image
 
 // #cgo pkg-config: sdl2
 // #cgo LDFLAGS: -lSDL2_image
 //
-// #include "SDL.h"
-//	#include "SDL_image.h"
+// #include "SDL_image.h"
 import "C"
 
 import "unsafe"
+
+func Init() {
+}
 
 func LoadImage(fileName string) (Surface, error) {
 	cName := C.CString(fileName)

--- a/sdl/event.go
+++ b/sdl/event.go
@@ -2,8 +2,6 @@ package sdl
 
 // TODO put these C functions in their own event.c file
 
-// #cgo pkg-config: sdl2
-//
 // #include "SDL.h"
 //
 // Uint32 GetType(SDL_Event* ev) {

--- a/sdl/event.go
+++ b/sdl/event.go
@@ -3,7 +3,6 @@ package sdl
 // TODO put these C functions in their own event.c file
 
 // #cgo pkg-config: sdl2
-// #cgo LDFLAGS: -lSDL2_image
 //
 // #include "SDL.h"
 //

--- a/sdl/pixel.go
+++ b/sdl/pixel.go
@@ -1,7 +1,5 @@
 package sdl
 
-// #cgo pkg-config: sdl2
-//
 // #include "SDL.h"
 //
 // static Uint32 goSDL_pixelFlag(Uint32 pixelFormat) {

--- a/sdl/rect.go
+++ b/sdl/rect.go
@@ -1,7 +1,6 @@
 package sdl
 
 // #cgo pkg-config: sdl2
-// #cgo LDFLAGS: -lSDL2_image
 //
 // #include "SDL.h"
 import "C"

--- a/sdl/rect.go
+++ b/sdl/rect.go
@@ -1,7 +1,5 @@
 package sdl
 
-// #cgo pkg-config: sdl2
-//
 // #include "SDL.h"
 import "C"
 

--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -1,8 +1,7 @@
-// Package sdl provides a binding of SDL2 and SDL2_image with an object-oriented twist.
+// Package sdl provides a binding of SDL2 with an object-oriented twist.
 package sdl
 
 // #cgo pkg-config: sdl2
-// #cgo LDFLAGS: -lSDL2_image
 //
 // #include "SDL.h"
 import "C"

--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -49,8 +49,10 @@ func (e Error) Error() string {
 	return "sdl: " + string(e)
 }
 
-// getError returns the current SDL error as a Go error value.
-func getError() error {
+// GetError returns the current SDL error as a Go error value.
+// This is internal to SDL but exported because it is cross-package.
+func GetError() error {
+	// TODO(light): synchronize access?
 	e := C.SDL_GetError()
 	if *e == 0 {
 		// empty string, no error.

--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -32,7 +32,7 @@ func Init(flags ...InitFlag) error {
 		f |= flags[i]
 	}
 	if C.SDL_Init(C.Uint32(f)) != 0 {
-		return getError()
+		return GetError()
 	}
 	return nil
 }

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -1,7 +1,6 @@
 package sdl
 
 // #cgo pkg-config: sdl2
-// #cgo LDFLAGS: -lSDL2_image
 //
 // #include "SDL.h"
 import "C"

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -1,7 +1,5 @@
 package sdl
 
-// #cgo pkg-config: sdl2
-//
 // #include "SDL.h"
 import "C"
 

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -12,8 +12,15 @@ import (
 	"unsafe"
 )
 
+// Surface is a rectangular array of pixels.
 type Surface struct {
 	s *C.SDL_Surface
+}
+
+// InternalSurface creates a surface from an SDL_Surface pointer.
+// This should only be used by other SDL packages.
+func InternalSurface(p unsafe.Pointer) Surface {
+	return Surface{(*C.SDL_Surface)(p)}
 }
 
 // PixelFormat returns the surface's pixel format.

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -31,7 +31,7 @@ func (surface Surface) PixelFormat() *PixelFormat {
 
 func (surface Surface) PixelData() (PixelData, error) {
 	if result := C.SDL_LockSurface(surface.s); result < 0 {
-		return PixelData{}, getError()
+		return PixelData{}, GetError()
 	}
 	return PixelData{s: surface.s}, nil
 }
@@ -40,7 +40,7 @@ func (surface Surface) PixelData() (PixelData, error) {
 func (surface Surface) ToTexture(renderer Renderer) (Texture, error) {
 	txt := C.SDL_CreateTextureFromSurface(renderer.r, surface.s)
 	if txt == nil {
-		return Texture{}, getError()
+		return Texture{}, GetError()
 	}
 	return Texture{txt}, nil
 }

--- a/sdl/texture.go
+++ b/sdl/texture.go
@@ -1,7 +1,6 @@
 package sdl
 
 // #cgo pkg-config: sdl2
-// #cgo LDFLAGS: -lSDL2_image
 //
 // #include "SDL.h"
 import "C"

--- a/sdl/texture.go
+++ b/sdl/texture.go
@@ -1,7 +1,5 @@
 package sdl
 
-// #cgo pkg-config: sdl2
-//
 // #include "SDL.h"
 import "C"
 

--- a/sdl/window.go
+++ b/sdl/window.go
@@ -1,7 +1,6 @@
 package sdl
 
 // #cgo pkg-config: sdl2
-// #cgo LDFLAGS: -lSDL2_image
 //
 // #include "SDL.h"
 import "C"

--- a/sdl/window.go
+++ b/sdl/window.go
@@ -1,7 +1,5 @@
 package sdl
 
-// #cgo pkg-config: sdl2
-//
 // #include "SDL.h"
 import "C"
 

--- a/sdl/window.go
+++ b/sdl/window.go
@@ -71,7 +71,7 @@ func NewWindow(title string, x, y, w, h int, flags WindowFlag) (Window, error) {
 		return Window{window, nil}, nil
 	}
 
-	return Window{}, getError()
+	return Window{}, GetError()
 }
 
 // Get the window's surface
@@ -90,13 +90,13 @@ func NewRenderer(window Window, index int, flags uint32) (Renderer, error) {
 		return Renderer{r}, nil
 	}
 
-	return Renderer{}, getError()
+	return Renderer{}, GetError()
 }
 
 func (w Window) Renderer() (Renderer, error) {
 	r := C.SDL_GetRenderer(w.w)
 	if r == nil {
-		return Renderer{}, getError()
+		return Renderer{}, GetError()
 	}
 	return Renderer{r}, nil
 }
@@ -104,7 +104,7 @@ func (w Window) Renderer() (Renderer, error) {
 func (r Renderer) Info() (*RendererInfo, error) {
 	var info C.SDL_RendererInfo
 	if C.SDL_GetRendererInfo(r.r, &info) != 0 {
-		return nil, getError()
+		return nil, GetError()
 	}
 
 	formats := make([]PixelFormatEnum, info.num_texture_formats)
@@ -136,7 +136,7 @@ func (r Renderer) CopyTexture(texture Texture, srcRect *Rect, destRect *Rect) er
 	}
 
 	if C.SDL_RenderCopy(r.r, texture.t, src, dest) != 0 {
-		return getError()
+		return GetError()
 	}
 	return nil
 }
@@ -144,7 +144,7 @@ func (r Renderer) CopyTexture(texture Texture, srcRect *Rect, destRect *Rect) er
 // Clear clears the current rendering target with the drawing color.
 func (r Renderer) Clear() error {
 	if C.SDL_RenderClear(r.r) != 0 {
-		return getError()
+		return GetError()
 	}
 	return nil
 }


### PR DESCRIPTION
This allows users of the package to install SDL_image separately from the main SDL library.
