### PR TITLE
Simple main thread

### DIFF
--- a/demos/showimage/showimage.go
+++ b/demos/showimage/showimage.go
@@ -14,7 +14,14 @@ var fullscreen = flag.Bool("fullscreen", false, "fullscreen window")
 
 func main() {
 	flag.Parse()
+	go sdl.Do(run)
+	sdl.Main()
+}
+
+func run() {
 	defer sdl.Quit()
+
+	sdl.Init(sdl.InitVideo)
 
 	// Open window
 	var windowFlags sdl.WindowFlag
@@ -64,10 +71,10 @@ mainLoop:
 				break
 			}
 			switch ev.Type() {
-			case sdl.QuitEv:
+			case sdl.QuitEventType:
 				fmt.Println("QUIT")
 				break mainLoop
-			case sdl.KeyDownEv:
+			case sdl.KeyDownEventType:
 				fmt.Println("KEY")
 				// TODO(light): advance texture
 			}

--- a/demos/showimage/showimage.go
+++ b/demos/showimage/showimage.go
@@ -23,7 +23,7 @@ func main() {
 	go sdl.Do(func() { err = run() })
 	sdl.Main()
 
-	if err := run(); err != nil {
+	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -37,6 +37,7 @@ import (
 )
 
 func init() {
+	// Force main to stay on main thread.
 	runtime.LockOSThread()
 
 	// Run SDL_Init as early as possible. The SDL wiki claims that creating threads

--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -1,10 +1,75 @@
-// Package sdl provides a binding of SDL2 with an object-oriented twist.
+/*
+Package sdl provides a binding of SDL2 with an object-oriented twist.
+
+The Do Function
+
+SDL is not an inherently thread-safe library, and some operating systems force
+windowing calls to be made on the main thread.  Thus, most functions in this
+package must be called from the Do function, and the main function must call
+sdl.Main.
+
+	package main
+
+	import "github.com/adam000/Go-SDL2/sdl"
+
+	func main() {
+		go run()
+		sdl.Main()
+	}
+
+	func run() {
+		defer sdl.Quit()
+
+		sdl.Do(func() {
+			// make SDL calls here
+		})
+	}
+*/
 package sdl
 
 // #cgo pkg-config: sdl2
 //
 // #include "SDL.h"
 import "C"
+
+import (
+	"runtime"
+)
+
+func init() {
+	runtime.LockOSThread()
+
+	// Run SDL_Init as early as possible. The SDL wiki claims that creating threads
+	// before calling SDL_Init is bad (but they should feel bad).
+	if C.SDL_Init(0) != 0 {
+		panic(GetError())
+	}
+}
+
+// Main runs the main SDL service loop.
+// The binary's main.main must call sdl.Main() to run this loop.
+// Main does not return.  If the binary needs to do other work, it
+// must do it in separate goroutines.
+func Main() {
+	// Taken from https://code.google.com/p/go-wiki/wiki/LockOSThread.
+	for f := range mainFunc {
+		f()
+	}
+}
+
+var mainFunc = make(chan func())
+
+// Do executes a function on the main thread.  Calls to Do cannot nest --
+// calling Do inside of a function passed to Do will cause deadlock.
+func Do(f func()) {
+	// Taken from https://code.google.com/p/go-wiki/wiki/LockOSThread.
+	done := make(chan bool, 1)
+	mainFunc <- func() {
+		f()
+		done <- true
+	}
+	<-done
+}
 
 // An InitFlag represents a set of SDL subsystems to initialize.
 type InitFlag uint32
@@ -23,14 +88,14 @@ const (
 	InitEverything InitFlag = C.SDL_INIT_EVERYTHING
 )
 
-// Init initializes SDL and its subsystems.  Multiple flags will be ORed together.
-// Init must be called before calling other functions in this package.
+// Init initializes SDL subsystems.  Multiple flags will be ORed together.
+// You don't have to call Init unless you need a particular subsystem.
 func Init(flags ...InitFlag) error {
 	var f InitFlag
 	for i := range flags {
 		f |= flags[i]
 	}
-	if C.SDL_Init(C.Uint32(f)) != 0 {
+	if C.SDL_InitSubSystem(C.Uint32(f)) != 0 {
 		return GetError()
 	}
 	return nil
@@ -51,7 +116,6 @@ func (e Error) Error() string {
 // GetError returns the current SDL error as a Go error value.
 // This is internal to SDL but exported because it is cross-package.
 func GetError() error {
-	// TODO(light): synchronize access?
 	e := C.SDL_GetError()
 	if *e == 0 {
 		// empty string, no error.

--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -48,8 +48,8 @@ func init() {
 
 // Main runs the main SDL service loop.
 // The binary's main.main must call sdl.Main() to run this loop.
-// Main does not return.  If the binary needs to do other work, it
-// must do it in separate goroutines.
+// If the binary needs to do other work, it must do it in separate goroutines.
+// Main will return after calling Quit.
 func Main() {
 	// Taken from https://code.google.com/p/go-wiki/wiki/LockOSThread.
 	for f := range mainFunc {
@@ -101,9 +101,10 @@ func Init(flags ...InitFlag) error {
 	return nil
 }
 
-// Quit cleans up SDL.
+// Quit cleans up SDL.  Main will return after calling Quit.
 func Quit() {
 	C.SDL_Quit()
+	close(mainFunc)
 }
 
 // Error stores an SDL error.


### PR DESCRIPTION
Allow optional, simple main thread management using `sdl.Do` and `sdl.Main`.
